### PR TITLE
make opengraph meta tags available without app id

### DIFF
--- a/tpl/layout/base.tpl
+++ b/tpl/layout/base.tpl
@@ -35,18 +35,19 @@
 
         [{block name="head_meta_open_graph"}]
             [{if $oViewConf->getFbAppId()}]
-                <meta property="og:site_name" content="[{$oViewConf->getBaseDir()}]">
                 <meta property="fb:app_id" content="[{$oViewConf->getFbAppId()}]">
-                <meta property="og:title" content="[{$sPageTitle}]">
-                [{if $oViewConf->getActiveClassName() == 'details'}]
-                    <meta property="og:type" content="product">
-                    <meta property="og:image" content="[{$oView->getActPicture()}]">
-                    <meta property="og:url" content="[{$oView->getCanonicalUrl()}]">
-                [{else}]
-                    <meta property="og:type" content="website">
-                    <meta property="og:image" content="[{$oViewConf->getImageUrl('basket.png')}]">
-                    <meta property="og:url" content="[{$oViewConf->getCurrentHomeDir()}]">
-                [{/if}]
+            [{/if}]
+            <meta property="og:site_name" content="[{$oViewConf->getBaseDir()}]">
+            <meta property="og:title" content="[{$sPageTitle}]">
+            <meta property="og:description" content="[{$oView->getMetaDescription()}]">
+            [{if $oViewConf->getActiveClassName() == 'details'}]
+                <meta property="og:type" content="product">
+                <meta property="og:image" content="[{$oView->getActPicture()}]">
+                <meta property="og:url" content="[{$oView->getCanonicalUrl()}]">
+            [{else}]
+                <meta property="og:type" content="website">
+                <meta property="og:image" content="[{$oViewConf->getImageUrl('basket.png')}]">
+                <meta property="og:url" content="[{$oViewConf->getCurrentHomeDir()}]">
             [{/if}]
         [{/block}]
 


### PR DESCRIPTION
open graph meta tags are part of structured data and should be available in template even if there is no facebook app id set.
There are also 1-2 acknowledget bug reports about this topic