### PR TITLE
add new block to order submit botton

### DIFF
--- a/tpl/page/checkout/order.tpl
+++ b/tpl/page/checkout/order.tpl
@@ -267,9 +267,12 @@
                             </div>
 
                             <div class="well well-sm">
+                                [{block name="checkout_order_btn_submit_bottom"}]
                                 <button type="submit" class="btn btn-lg btn-primary pull-right submitButton nextStep largeButton">
                                     <i class="fa fa-check"></i> [{oxmultilang ident="SUBMIT_ORDER"}]
                                 </button>
+                                [{/block}]
+
                                 <div class="clearfix"></div>
                             </div>
                         </form>


### PR DESCRIPTION
the new block make it possible for modules to add things to the button/form without replacing the full form.
The benefit the new block for developers brings, is that they can call smarty.parent in there module and so make there modules compatible to each other.
