### PR TITLE
Modification for showing error messages with destination 'popup'

### DIFF
--- a/tpl/message/errors.tpl
+++ b/tpl/message/errors.tpl
@@ -1,5 +1,8 @@
-[{if count($Errors)>0 && count($Errors.default) > 0}]
+[{if count($Errors)>0 && ( count($Errors.default) > 0 || count($Errors.popup) > 0 )}]
     [{foreach from=$Errors.default item=oEr key=key}]
+        <p class="alert alert-danger">[{$oEr->getOxMessage()}]</p>
+    [{/foreach}]
+    [{foreach from=$Errors.popup item=oEr key=key}]
         <p class="alert alert-danger">[{$oEr->getOxMessage()}]</p>
     [{/foreach}]
 [{/if}]


### PR DESCRIPTION
Modification for showing error messages with destination 'popup' although the theme option 'Select action when product is added to cart' is set to 'Open popup'. 
