### PR TITLE
Added block for overwrite svg icons in modules

### DIFF
--- a/tpl/layout/base.tpl
+++ b/tpl/layout/base.tpl
@@ -210,9 +210,11 @@
     <body class="cl-[{$oView->getClassName()}][{if $smarty.get.plain == '1'}] popup[{/if}][{if $blIsCheckout}] is-checkout[{/if}][{if $oxcmp_user && $oxcmp_user->oxuser__oxpassword->value}] is-logged-in[{/if}]"[{if $sStyle}] style="[{$sStyle}]"[{/if}]>
 
         [{* Theme SVG icons *}]
-        <div style="display: none;">
-            [{include file="layout/svg/shoppingbag.svg" count=$oxcmp_basket->getItemsCount()}]
-        </div>
+        [{block name="theme_svg_icons"}]
+            <div style="display: none;">
+                [{include file="layout/svg/shoppingbag.svg" count=$oxcmp_basket->getItemsCount()}]
+            </div>
+        [{/block}]
 
         <div class="[{if $blFullwidth}]fullwidth-container[{else}]container[{/if}]">
             <div class="main-row">


### PR DESCRIPTION
Sometimes the need may occur to overwrite the svg icons aka the shopping bag icon the set your own in a module. Therefore i added a block to make this easyly possible.