### PR TITLE
Bugfix 6434 for master branch

### DIFF
--- a/tpl/widget/product/listitem_grid.tpl
+++ b/tpl/widget/product/listitem_grid.tpl
@@ -127,9 +127,9 @@
                                     <i class="fa fa-shopping-cart"></i>
                                 </button>
                             [{/oxhasrights}]
-                            <a class="btn btn-primary" href="[{$_productLink}]" >[{oxmultilang ident="MORE_INFO"}]</a>
+                            <a class="btn btn-primary" href="[{$_productLink}]" >[{oxmultilang ident="DETAILS"}]</a>
                         [{else}]
-                            <a class="btn btn-primary" href="[{$_productLink}]" >[{oxmultilang ident="MORE_INFO"}]</a>
+                            <a class="btn btn-primary" href="[{$_productLink}]" >[{oxmultilang ident="DETAILS"}]</a>
                         [{/if}]
                     </div>
                 </div>


### PR DESCRIPTION
regarding bug #6434: https://bugs.oxid-esales.com/view.php?id=6434
"more information" or german "mehr Informationen" require very much place and force line breaks between buttons. The easies fix would be replacing "more information" with simple "details"
