### PR TITLE
make product locator optional on detail page

### DIFF
--- a/tpl/page/details/details.tpl
+++ b/tpl/page/details/details.tpl
@@ -54,7 +54,9 @@
                         [{/if}]
                     </div>
                     <div class="col-xs-3 text-center pager-current-page">
-                        [{oxmultilang ident="PRODUCT"}] [{$actCategory->iProductPos}] [{oxmultilang ident="OF"}] [{$actCategory->iCntOfProd}]
+                        [{if $actCategory->iProductPos}]
+                            [{oxmultilang ident="PRODUCT"}] [{$actCategory->iProductPos}] [{oxmultilang ident="OF"}] [{$actCategory->iCntOfProd}]
+                        [{/if}]
                     </div>
                     <div class="col-xs-3 text-right pager-next">
                         [{if $actCategory->nextProductLink}]


### PR DESCRIPTION
on detail page we have an optional back and next link, but the the current position of the article was not optional in the template.
For us it is important to have this optional because it is not always possible to locate the article (sometimes not simple without loosing performance). Without this change you sometimes get a broken view.
