### PR TITLE
Responsive "more links" in mainnav will not collapse correctly

### DIFF
--- a/build/js/main.js
+++ b/build/js/main.js
@@ -310,7 +310,7 @@ $( function ()
             $oNavItems.each( function ()
                 {
                     var $this = $( this );
-                    iNavItemsWidth += $this.outerWidth();
+                    iNavItemsWidth += $this.outerWidth(true);
 
                     if ( iNavItemsWidth > iMainNavWidth )
                     {


### PR DESCRIPTION
The calculation in main.js uses outerWidth of the elements without setting the parameter "includeMargin" to true. Adding margin to the nav items will lead to incorrect calculations. See http://api.jquery.com/outerwidth/#outerWidth-includeMargin
