### PR TITLE
svg-Icon for the shoppingbag is not dynamically

### DIFF
--- a/tpl/layout/base.tpl
+++ b/tpl/layout/base.tpl
@@ -214,9 +214,7 @@
 
         [{* Theme SVG icons *}]
         [{block name="theme_svg_icons"}]
-        <div style="display: none;">
-            [{include file="layout/svg/shoppingbag.svg" count=$oxcmp_basket->getItemsCount()}]
-        </div>
+
         [{/block}]
 
         <div class="[{if $blFullwidth}]fullwidth-container[{else}]container[{/if}]">

--- a/tpl/widget/header/minibasket.tpl
+++ b/tpl/widget/header/minibasket.tpl
@@ -1,3 +1,6 @@
+<div style="display: none;">
+    [{include file="layout/svg/shoppingbag.svg" count=$oxcmp_basket->getItemsCount()}]
+</div>
 <div class="btn-group minibasket-menu">
     <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" data-href="[{oxgetseourl ident=$oViewConf->getSelfLink()|cat:"cl=basket"}]">
         [{block name="dd_layout_page_header_icon_menu_minibasket_button"}]


### PR DESCRIPTION
The svg-Icon for the shoppingbag has to be moved within the template of minibasket widget, as the counter in the shopping bag has to be also set dynamically if the widget is loaded dynamically (varnish or ajax).