### PR TITLE
fix for navbar dropdowns on mobile devices

### DIFF
--- a/build/js/main.js
+++ b/build/js/main.js
@@ -156,7 +156,7 @@ $( function ()
             }
         ).on( 'click', 'li.dropdown', function ( e )
             {
-                e.stopPropagation();
+                if ( $window.width() >= 760 ) e.stopPropagation();
             }
         );
 


### PR DESCRIPTION
By default bootstrap dropdowns open on click.
When windows.width >= 760 px, this behavior is changed to open dropdowns on hover. Therefore click event is prevented. But his breaks dropdown functionality on mobile devices, since click event is always prevented, no matter of window width.

For top categories with dropdowns, href attribute also should be removed/replaced with simple "#" to make dropdowns toggleable on mobile devices, otherwise it works just like a link and opens it's url.
This is how i did it for my theme: https://github.com/vanilla-thunder/glow/blob/master/tpl/widget/header/categorylist.tpl#L55
but it also could be done with a javascript.