### PR TITLE
Bug 6560: Display private sales login error messages

### DIFF
--- a/tpl/page/privatesales/login.tpl
+++ b/tpl/page/privatesales/login.tpl
@@ -18,7 +18,7 @@
             [{include file="form/privatesales/accept_terms.tpl"}]
         [{else}]
             [{include file="widget/header/languages.tpl"}]
-            <p>[{oxmultilang ident="LOGIN_ALREADY_CUSTOMER"}]</p>
+            [{include file="message/errors.tpl"}]
             [{include file="form/login_account.tpl"}]
         [{/if}]
     </div>


### PR DESCRIPTION
Private sales login error messages are now displayed the same way as the error messages displayed during an account login with private sales deactivated. The language variable "LOGIN_ALREADY_CUSTOMER" was removed because the same text was included in the file "form/login_account.tpl" and hence is currently displayed twice. The fix is similar to the fix made for the Bug 6079 in the Azure theme.