### PR TITLE
Fixing css style names in basketcontents-templates

### DIFF
--- a/tpl/page/checkout/inc/basketcontents_list.tpl
+++ b/tpl/page/checkout/inc/basketcontents_list.tpl
@@ -25,11 +25,11 @@
                             [{if $editable}]</a>[{/if}]
                             [{if $basketitem->isSkipDiscount()}] <sup><a href="#SkipDiscounts_link" >**</a></sup>[{/if}]
 
-                            <div class="smallFont">
+                            <div class="small">
                                 [{oxmultilang ident="PRODUCT_NO"}] [{$basketproduct->oxarticles__oxartnum->value}]
                             </div>
 
-                            <div class="smallFont">
+                            <div class="small">
                                 [{assign var=sep value=", "}]
                                 [{assign var=result value=""}]
                                 [{foreach key="oArtAttributes" from=$oAttributes->getArray() item="oAttr" name="attributeContents"}]

--- a/tpl/page/checkout/inc/basketcontents_table.tpl
+++ b/tpl/page/checkout/inc/basketcontents_table.tpl
@@ -59,10 +59,10 @@
                                         <b>[{$basketitem->getTitle()}]</b>
                                         [{if $editable}]</a>[{/if}]
                                     [{if $basketitem->isSkipDiscount()}] <sup><a href="#SkipDiscounts_link" >**</a></sup>[{/if}]
-                                    <div class="smallFont">
+                                    <div class="small">
                                         [{oxmultilang ident="PRODUCT_NO"}] [{$basketproduct->oxarticles__oxartnum->value}]
                                     </div>
-                                    <div class="smallFont">
+                                    <div class="small">
                                         [{assign var=sep value=", "}]
                                         [{assign var=result value=""}]
                                         [{foreach key=oArtAttributes from=$oAttributes->getArray() item=oAttr name=attributeContents}]


### PR DESCRIPTION
css style smallFont doesn't exists in bootstrap and in flow theme too
bootstrap uses .small class