### PR TITLE
fix: alignment for payment desciption

### DIFF
--- a/tpl/page/checkout/inc/payment_oxidcreditcard.tpl
+++ b/tpl/page/checkout/inc/payment_oxidcreditcard.tpl
@@ -80,8 +80,12 @@
 
         [{block name="checkout_payment_longdesc"}]
             [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                <div class="alert alert-info col-lg-offset-3 desc">
-                    [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+				<div class="row">
+					<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+						<div class="alert alert-info desc">
+							[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+						</div>
+					</div>
                 </div>
             [{/if}]
         [{/block}]

--- a/tpl/page/checkout/inc/payment_oxiddebitnote.tpl
+++ b/tpl/page/checkout/inc/payment_oxiddebitnote.tpl
@@ -32,8 +32,12 @@
 
         [{block name="checkout_payment_longdesc"}]
             [{if $paymentmethod->oxpayments__oxlongdesc->value}]
-                <div class="alert alert-info col-lg-offset-3 desc">
-                    [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+				<div class="row">
+					<div class="col-xs-12 col-lg-9 col-lg-offset-3">
+						<div class="alert alert-info desc">
+							[{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
+						</div>
+					</div>
                 </div>
             [{/if}]
         [{/block}]


### PR DESCRIPTION
For payment options the description (Bootstrap `.alert`) is not aligned with input fields above, because grid and alert CSS classes are mixed.

![alignment-before](https://cloud.githubusercontent.com/assets/1481657/25427473/f932acb0-2a72-11e7-8ee5-d9cf5e804cbc.png)

I refactored the alert into it's own grid container:

![alignment-after](https://cloud.githubusercontent.com/assets/1481657/25427488/0689867c-2a73-11e7-97b3-8e0880e53d2c.png)

This applies to the creditcard and debit forms.
