### PR TITLE
fix: add cart-buttons class to all prev/next button wells inside checkout

### DIFF
--- a/tpl/form/user_checkout_change.tpl
+++ b/tpl/form/user_checkout_change.tpl
@@ -35,7 +35,7 @@
             <input type="hidden" name="blshowshipaddress" value="1">
 
             [{block name="user_checkout_change_next_step_top"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default pull-left prevStep submitButton largeButton" id="userBackStepTop"><i class="fa fa-caret-left"></i> [{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <button id="userNextStepTop" class="btn btn-primary pull-right submitButton largeButton nextStep" name="userform" type="submit">[{oxmultilang ident="CONTINUE_TO_NEXT_STEP"}] <i class="fa fa-caret-right"></i></button>
                     <div class="clearfix"></div>
@@ -114,7 +114,7 @@
             </div>
 
             [{block name="user_checkout_change_next_step_bottom"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default pull-left prevStep submitButton largeButton" id="userBackStepBottom"><i class="fa fa-caret-left"></i> [{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <button id="userNextStepBottom" class="btn btn-primary pull-right submitButton largeButton nextStep" name="userform" type="submit">[{oxmultilang ident="CONTINUE_TO_NEXT_STEP"}] <i class="fa fa-caret-right"></i></button>
                     <div class="clearfix"></div>

--- a/tpl/form/user_checkout_noregistration.tpl
+++ b/tpl/form/user_checkout_noregistration.tpl
@@ -43,7 +43,7 @@
             </div>
 
             [{block name="user_checkout_noregistration_next_step_top"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default prevStep submitButton largeButton" id="userBackStepTop">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <div class="clearfix"></div>
                 </div>
@@ -93,7 +93,7 @@
             [{oxscript add="$('#showShipAddress').change( function() { $('#shippingAddress').toggle($(this).is(':not(:checked)'));});"}]
 
             [{block name="user_checkout_noregistration_next_step_bottom"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default pull-left prevStep submitButton largeButton" id="userBackStepBottom">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <button id="userNextStepBottom" class="btn btn-primary pull-right submitButton largeButton nextStep" name="userform" type="submit">[{oxmultilang ident="CONTINUE_TO_NEXT_STEP"}]</button>
                     <div class="clearfix"></div>

--- a/tpl/form/user_checkout_registration.tpl
+++ b/tpl/form/user_checkout_registration.tpl
@@ -43,7 +43,7 @@
             </div>
 
             [{block name="user_checkout_registration_next_step_top"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default prevStep submitButton largeButton" id="userBackStepTop">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <div class="clearfix"></div>
                 </div>
@@ -95,7 +95,7 @@
             [{oxscript add="$('#showShipAddress').change( function() { $('#shippingAddress').toggle($(this).is(':not(:checked)'));});"}]
 
             [{block name="user_checkout_registration_next_step_bottom"}]
-                <div class="well well-sm">
+                <div class="well well-sm cart-buttons">
                     <a href="[{oxgetseourl ident=$oViewConf->getBasketLink()}]" class="btn btn-default pull-left prevStep submitButton largeButton" id="userBackStepBottom">[{oxmultilang ident="PREVIOUS_STEP"}]</a>
                     <button id="userNextStepBottom" class="btn btn-primary pull-right submitButton largeButton nextStep" name="userform" type="submit">[{oxmultilang ident="CONTINUE_TO_NEXT_STEP"}]</button>
                     <div class="clearfix"></div>

--- a/tpl/page/checkout/basket.tpl
+++ b/tpl/page/checkout/basket.tpl
@@ -24,7 +24,7 @@
             [{/block}]
         [{else}]
             [{block name="checkout_basket_next_step_top"}]
-                <div class="well well-sm clear cart-buttons">
+                <div class="well well-sm cart-buttons">
                     [{block name="checkout_basket_backtoshop_top"}]
                         [{if $oView->showBackToShop()}]
                             <form action="[{$oViewConf->getSslSelfLink()}]" method="post" class="pull-left">
@@ -66,7 +66,7 @@
             </div>
 
             [{block name="checkout_basket_next_step_bottom"}]
-                <div class="well well-sm clear cart-buttons">
+                <div class="well well-sm cart-buttons">
                     [{block name="checkout_basket_loworderprice_bottom"}][{/block}]
 
                     [{block name="checkout_basket_backtoshop_bottom"}]

--- a/tpl/page/checkout/order.tpl
+++ b/tpl/page/checkout/order.tpl
@@ -266,7 +266,7 @@
                                 <input type="hidden" name="oxserviceproductsagreement" value="0">
                             </div>
 
-                            <div class="well well-sm">
+                            <div class="well well-sm cart-buttons">
                                 [{block name="checkout_order_btn_submit_bottom"}]
                                 <button type="submit" class="btn btn-lg btn-primary pull-right submitButton nextStep largeButton">
                                     <i class="fa fa-check"></i> [{oxmultilang ident="SUBMIT_ORDER"}]

--- a/tpl/page/checkout/payment.tpl
+++ b/tpl/page/checkout/payment.tpl
@@ -128,7 +128,7 @@
                                 <b>[{oxmultilang ident="MIN_ORDER_PRICE"}] [{$oView->getMinOrderPrice()}] [{$currency->sign}]</b>
                             </div>
                         [{else}]
-                            <div class="well well-sm">
+                            <div class="well well-sm cart-buttons">
                                 <a href="[{oxgetseourl ident=$oViewConf->getOrderLink()}]" class="btn btn-default pull-left prevStep submitButton largeButton" id="paymentBackStepBottom"><i class="fa fa-caret-left"></i> [{oxmultilang ident="PREVIOUS_STEP"}]</a>
                                 <button type="submit" name="userform" class="btn btn-primary pull-right submitButton nextStep largeButton" id="paymentNextStepBottom">[{oxmultilang ident="CONTINUE_TO_NEXT_STEP"}] <i class="fa fa-caret-right"></i></button>
                                 <div class="clearfix"></div>


### PR DESCRIPTION
On the basket step the prev/next buttons have a cart-buttons class on the well-wrapper. This PR adds this class to the other checkout steps.