### PR TITLE
use getTitle from model and not from controller (list.tpl)

### DIFF
--- a/tpl/page/list/list.tpl
+++ b/tpl/page/list/list.tpl
@@ -32,7 +32,7 @@
         <div class="page-header">
             [{assign var='rsslinks' value=$oView->getRssLinks()}]
             <h1>
-                [{$oView->getTitle()}]
+                [{$actCategory->getTitle()}]
                 [{if $rsslinks.activeCategory}]
                     <a class="rss" id="rssActiveCategory" href="[{$rsslinks.activeCategory.link}]" title="[{$rsslinks.activeCategory.title}]" target="_blank">
                         <i class="fa fa-rss"></i>


### PR DESCRIPTION
Use getTitle from actCategory object, so the h1 title in the template can differ from the meta tag title  . So it is easier to overwrite the meta title with a module and the h1 title is not changed.
More information here: https://bugs.oxid-esales.com/view.php?id=6542