### PR TITLE
fix: show deliverytime wrapper only if deliverytime is available

### DIFF
--- a/tpl/page/details/inc/deliverytime.tpl
+++ b/tpl/page/details/inc/deliverytime.tpl
@@ -1,14 +1,16 @@
 [{if $oDetailsProduct->oxarticles__oxmindeltime->value || $oDetailsProduct->oxarticles__oxmaxdeltime->value}]
-    [{oxmultilang ident="DELIVERYTIME_DELIVERYTIME" suffix="COLON"}]
-    [{if $oDetailsProduct->oxarticles__oxmindeltime->value && $oDetailsProduct->oxarticles__oxmindeltime->value != $oDetailsProduct->oxarticles__oxmaxdeltime->value}]
-        [{$oDetailsProduct->oxarticles__oxmindeltime->value}] -
-    [{/if}]
-    [{if $oDetailsProduct->oxarticles__oxmaxdeltime->value}]
-        [{assign var="unit" value=$oDetailsProduct->oxarticles__oxdeltimeunit->value}]
-        [{assign var="ident" value=$unit}]
-        [{if $oDetailsProduct->oxarticles__oxmaxdeltime->value > 1}]
-            [{assign var="ident" value=$ident|cat:"S"}]
-        [{/if}]
-        [{$oDetailsProduct->oxarticles__oxmaxdeltime->value}] [{oxmultilang ident=$ident}]
-    [{/if}]
+	<span class="deliverytime">
+		[{oxmultilang ident="DELIVERYTIME_DELIVERYTIME" suffix="COLON"}]
+		[{if $oDetailsProduct->oxarticles__oxmindeltime->value && $oDetailsProduct->oxarticles__oxmindeltime->value != $oDetailsProduct->oxarticles__oxmaxdeltime->value}]
+			[{$oDetailsProduct->oxarticles__oxmindeltime->value}] -
+		[{/if}]
+		[{if $oDetailsProduct->oxarticles__oxmaxdeltime->value}]
+			[{assign var="unit" value=$oDetailsProduct->oxarticles__oxdeltimeunit->value}]
+			[{assign var="ident" value=$unit}]
+			[{if $oDetailsProduct->oxarticles__oxmaxdeltime->value > 1}]
+				[{assign var="ident" value=$ident|cat:"S"}]
+			[{/if}]
+			[{$oDetailsProduct->oxarticles__oxmaxdeltime->value}] [{oxmultilang ident=$ident}]
+		[{/if}]
+	</span>
 [{/if}]

--- a/tpl/page/details/inc/productmain.tpl
+++ b/tpl/page/details/inc/productmain.tpl
@@ -299,11 +299,9 @@
 
                     [{oxhasrights ident="TOBASKET"}]
                         [{if $oDetailsProduct->isBuyable()}]
-                            <span class="deliverytime">
-                                [{block name="details_productmain_deliverytime"}]
-                                    [{include file="page/details/inc/deliverytime.tpl"}]
-                                [{/block}]
-                            </span>
+							[{block name="details_productmain_deliverytime"}]
+								[{include file="page/details/inc/deliverytime.tpl"}]
+							[{/block}]
                         [{/if}]
                     [{/oxhasrights}]
 


### PR DESCRIPTION
The span class is styled, and was allwazs rednered. So even if no delivery time is available the seperator styling would be shown in the template.

This fix moves the wrapper inside the condition to check for the deliverytime.