### PR TITLE
Fix für Javascript Toggle-Buttons in CategoryTree ( responsive @media…

### DIFF
--- a/build/js/main.js
+++ b/build/js/main.js
@@ -216,8 +216,8 @@ $( function ()
                     }
                     else
                     {
-                        $this.removeClass( 'fs-caret-up' );
-                        $this.attr( 'class', 'fs-caret-down ' + $this.attr( 'class' ) );
+                        $this.removeClass( 'fa-caret-up' );
+                        $this.attr( 'class', 'fa-caret-down ' + $this.attr( 'class' ) );
                         $oCategoryTreeBox.removeAttr( 'style' );
                     }
                 }


### PR DESCRIPTION
Typo error in main.js, where instead of classes 'fa-caret-*', was typed 'fs-caret-*'
The same problem is in kthe master branch too