### PR TITLE
replace missing translations in email templates

### DIFF
--- a/tpl/email/html/order_cust.tpl
+++ b/tpl/email/html/order_cust.tpl
@@ -373,7 +373,8 @@
                         [{if $basket->isProportionalCalculationOn()}]
                             <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="BASKET_TOTAL_PLUS_PROPORTIONAL_VAT"}]:</td>
                         [{else}]
-                            <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="PLUS_VAT"}] [{$basket->getPayCostVatPercent()}][{oxmultilang ident="SHIPPING_VAT2"}]</td>
+                            [{assign var="iPayCostVatPercent" value=$basket->getPayCostVatPercent()}]
+                            <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$iPayCostVatPercent}]</td>
                         [{/if}]
                         <td align="right" class="odd text-right">[{$basket->getPayCostVat()}] [{$currency->sign}]</td>
                     </tr>
@@ -420,7 +421,8 @@
                             [{if $basket->isProportionalCalculationOn()}]
                                 <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="BASKET_TOTAL_PLUS_PROPORTIONAL_VAT"}]:</td>
                             [{else}]
-                                <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="PLUS_VAT"}] [{$basket->getGiftCardCostVatPercent()}][{oxmultilang ident="SHIPPING_VAT2"}]:</td>
+                                [{assign var="iGiftCardCostVatPercent" value=$basket->getGiftCardCostVatPercent()}]
+                                <td align="right" colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$iGiftCardCostVatPercent}]</td>
                             [{/if}]
                             <td align="right" class="odd text-right">[{$basket->getGiftCardCostVat()}] [{$currency->sign}]</td>
                         </tr>

--- a/tpl/email/html/order_owner.tpl
+++ b/tpl/email/html/order_owner.tpl
@@ -233,7 +233,7 @@
                 <!-- VATs -->
                 [{foreach from=$basket->getProductVats() item=VATitem key=key}]
                     <tr valign="top" bgcolor="#ebebeb">
-                        <td colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="EMAIL_ORDER_CUST_HTML_PLUSTAX1"}] [{$key}][{oxmultilang ident="SHIPPING_VAT2"}]</td>
+                        <td colspan="[{$iFooterColspan}]" class="odd text-right">[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$key}]</td>
                         <td align="right" class="odd text-right">[{$VATitem}] [{$currency->sign}]</td>
                     </tr>
                 [{/foreach}]

--- a/tpl/email/plain/order_cust.tpl
+++ b/tpl/email/plain/order_cust.tpl
@@ -70,7 +70,7 @@
 [{block name="email_plain_order_cust_nodiscountproductvats"}]
 [{* VATs *}]
 [{foreach from=$basket->getProductVats() item=VATitem key=key}]
-[{oxmultilang ident="EMAIL_ORDER_CUST_HTML_PLUSTAX1"}] [{$key}][{oxmultilang ident="SHIPPING_VAT2"}] [{$VATitem}] [{$currency->name}]
+[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$key}] [{$VATitem}] [{$currency->name}]
 [{/foreach}]
 [{/block}]
 [{block name="email_plain_order_cust_nodiscounttotalgross"}]

--- a/tpl/email/plain/order_owner.tpl
+++ b/tpl/email/plain/order_owner.tpl
@@ -55,7 +55,7 @@
 [{block name="email_plain_order_ownernodiscountproductvats"}]
 [{* VATs *}]
 [{foreach from=$basket->getProductVats() item=VATitem key=key}]
-[{oxmultilang ident="EMAIL_ORDER_CUST_HTML_PLUSTAX1"}] [{$key}][{oxmultilang ident="SHIPPING_VAT2"}] [{$VATitem}] [{$currency->name}]
+[{oxmultilang ident="VAT_PLUS_PERCENT_AMOUNT" suffix="COLON" args=$key}] [{$VATitem}] [{$currency->name}]
 [{/foreach}]
 [{/block}]
 [{block name="email_plain_order_nodiscountownertotalgross"}]


### PR DESCRIPTION
Replace missing translations in email templates. 
See bug: https://bugs.oxid-esales.com/view.php?id=6437