### PR TITLE
change single quotes into double quotes in js_vars.tpl

### DIFF
--- a/tpl/i18n/js_vars.tpl
+++ b/tpl/i18n/js_vars.tpl
@@ -2,13 +2,13 @@
     var oFlow = oFlow || [];
     oFlow.i18n =
         {
-            DD_FORM_VALIDATION_VALIDEMAIL:     '[{oxmultilang ident="DD_FORM_VALIDATION_VALIDEMAIL"}]',
-            DD_FORM_VALIDATION_PASSWORDAGAIN:  '[{oxmultilang ident="DD_FORM_VALIDATION_PASSWORDAGAIN"}]',
-            DD_FORM_VALIDATION_NUMBER:         '[{oxmultilang ident="DD_FORM_VALIDATION_NUMBER"}]',
-            DD_FORM_VALIDATION_INTEGER:        '[{oxmultilang ident="DD_FORM_VALIDATION_INTEGER"}]',
-            DD_FORM_VALIDATION_POSITIVENUMBER: '[{oxmultilang ident="DD_FORM_VALIDATION_POSITIVENUMBER"}]',
-            DD_FORM_VALIDATION_NEGATIVENUMBER: '[{oxmultilang ident="DD_FORM_VALIDATION_NEGATIVENUMBER"}]',
-            DD_FORM_VALIDATION_REQUIRED:       '[{oxmultilang ident="DD_FORM_VALIDATION_REQUIRED"}]',
-            DD_FORM_VALIDATION_CHECKONE:       '[{oxmultilang ident="DD_FORM_VALIDATION_CHECKONE"}]'
+            DD_FORM_VALIDATION_VALIDEMAIL:     "[{oxmultilang ident="DD_FORM_VALIDATION_VALIDEMAIL"}]",
+            DD_FORM_VALIDATION_PASSWORDAGAIN:  "[{oxmultilang ident="DD_FORM_VALIDATION_PASSWORDAGAIN"}]",
+            DD_FORM_VALIDATION_NUMBER:         "[{oxmultilang ident="DD_FORM_VALIDATION_NUMBER"}]",
+            DD_FORM_VALIDATION_INTEGER:        "[{oxmultilang ident="DD_FORM_VALIDATION_INTEGER"}]",
+            DD_FORM_VALIDATION_POSITIVENUMBER: "[{oxmultilang ident="DD_FORM_VALIDATION_POSITIVENUMBER"}]",
+            DD_FORM_VALIDATION_NEGATIVENUMBER: "[{oxmultilang ident="DD_FORM_VALIDATION_NEGATIVENUMBER"}]",
+            DD_FORM_VALIDATION_REQUIRED:       "[{oxmultilang ident="DD_FORM_VALIDATION_REQUIRED"}]",
+            DD_FORM_VALIDATION_CHECKONE:       "[{oxmultilang ident="DD_FORM_VALIDATION_CHECKONE"}]"
         };
 </script>


### PR DESCRIPTION
change single quotes into double quotes as this cause problems with french language strings

French translations (e.g. 'DD_FORM_VALIDATION_VALIDEMAIL' => 'S\'il vous plaît, mettez une adresse email valide.') causes problems with javascript code and throws javascript errors