### PR TITLE
fix: Don't read image from disk, when proxy is active

### DIFF
--- a/tpl/page/details/inc/morepics.tpl
+++ b/tpl/page/details/inc/morepics.tpl
@@ -11,8 +11,14 @@
         <ul class="[{if $iMorePics > 4}]slides[{else}]list-inline[{/if}]">
             [{oxscript add="var aMorePic=new Array();"}]
             [{foreach from=$oView->getIcons() key="iPicNr" item="oArtIcon" name="sMorePics"}]
-                [{assign var="sPictureName" value=$oPictureProduct->getPictureFieldValue("oxpic", $iPicNr)}]
-                [{assign var="aPictureInfo" value=$oConfig->getMasterPicturePath("product/`$iPicNr`/`$sPictureName`")|@getimagesize}]
+                [{* ToDo: This logical part should be ported into a core function. *}]
+                [{if $oConfig->getConfigParam('sAltImageUrl') || $oConfig->getConfigParam('sSSLAltImageUrl')}]
+                    [{assign var="aPictureInfo" value=$oPictureProduct->getMasterZoomPictureUrl($iPicNr)|@getimagesize}]
+                [{else}]
+                    [{assign var="sPictureName" value=$oPictureProduct->getPictureFieldValue("oxpic", $iPicNr)}]
+                    [{assign var="aPictureInfo" value=$oConfig->getMasterPicturePath("product/`$iPicNr`/`$sPictureName`")|@getimagesize}]
+                [{/if}]
+
                 <li>
                     <a id="morePics_[{$smarty.foreach.sMorePics.iteration}]" [{if $smarty.foreach.sMorePics.first}] class="selected"[{/if}] href="[{$oPictureProduct->getPictureUrl($iPicNr)}]" data-num="[{$smarty.foreach.sMorePics.iteration}]"[{if $aPictureInfo}] data-width="[{$aPictureInfo.0}]" data-height="[{$aPictureInfo.1}]"[{/if}] data-zoom-url="[{$oPictureProduct->getMasterZoomPictureUrl($iPicNr)}]">
                         <img src="[{$oPictureProduct->getIconUrl($iPicNr)}]" alt="morepic-[{$smarty.foreach.sMorePics.iteration}]">


### PR DESCRIPTION
When the proxy is enabled and getImageSize() can't find the file on disk, an PHP error is thrown.

It's an extension of the implementaion in productmain.tpl (look for the same comment)