### PR TITLE
There is no need to have a light blue payment description...

### DIFF
--- a/tpl/page/checkout/inc/payment_other.tpl
+++ b/tpl/page/checkout/inc/payment_other.tpl
@@ -31,7 +31,7 @@
 
         [{block name="checkout_payment_longdesc"}]
             [{if $paymentmethod->oxpayments__oxlongdesc->value|strip_tags|trim}]
-                <div class="alert alert-info col-lg-offset-3 desc">
+                <div class="col-lg-offset-3 desc">
                     [{$paymentmethod->oxpayments__oxlongdesc->getRawValue()}]
                 </div>
             [{/if}]


### PR DESCRIPTION
...as the other payment descriptions don't have it, too.