### PR TITLE
6886: exclude non-essential files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+/build/ export-ignore
+/grunt/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/Gruntfile.js export-ignore
+/package.json export-ignore


### PR DESCRIPTION
* [esales bugtrack #6886](https://bugs.oxid-esales.com/view.php?id=6886)
* https://github.com/OXID-eSales/oxideshop_ce/pull/673
