### PR TITLE
Fixed icon class on the account dashboard button

### DIFF
--- a/tpl/page/account/dashboard.tpl
+++ b/tpl/page/account/dashboard.tpl
@@ -139,7 +139,7 @@
         [{/block}]
         <div class="col-xs-6 text-right">
             <a href="[{$oViewConf->getLogoutLink()}]" class="btn btn-warning" role="getLogoutLink">
-                <i class="fa fa-off"></i> [{oxmultilang ident="LOGOUT"}]
+                <i class="fa fa-power-off"></i> [{oxmultilang ident="LOGOUT"}]
             </a>
         </div>
         <p>&nbsp;</p>


### PR DESCRIPTION
Just a small fix: The Icon on the account dashboard button wasn't visible because the wrong FontAwesome class name was used ("fa-off" instead of "fa-power-off").