### PR TITLE
Add custom javascript hook/callback for custom scripting

### DIFF
--- a/build/vendor/oxid-esales/js/oxarticlevariant.js
+++ b/build/vendor/oxid-esales/js/oxarticlevariant.js
@@ -54,6 +54,9 @@
                     'additionalData' : aOptions,
                     'onSuccess' : function(r) {
                         $( contentTarget ).parent().html( r );
+                        try {
+                            ajaxExecuteTemplateScripts($, activator, highlightTargets, contentTarget, aOptions);
+                        } catch(e) {}
                         if ( typeof WidgetsHandler !== 'undefined') {
                             WidgetsHandler.reloadWidget('oxwarticledetails');
                             WidgetsHandler.reloadWidget('oxwrating');

--- a/build/vendor/oxid-esales/js/oxarticlevariant.js
+++ b/build/vendor/oxid-esales/js/oxarticlevariant.js
@@ -54,9 +54,16 @@
                     'additionalData' : aOptions,
                     'onSuccess' : function(r) {
                         $( contentTarget ).parent().html( r );
-                        try {
-                            ajaxExecuteTemplateScripts($, activator, highlightTargets, contentTarget, aOptions);
-                        } catch(e) {}
+                        if(oxTemplateCallbacks !== undefined && oxTemplateCallbacks.length) {
+                            for(var i in oxTemplateCallbacks) {
+                                if(typeof oxTemplateCallbacks[i] === 'function') {
+                                    try {
+                                        oxTemplateCallbacks[i]($, activator, highlightTargets, contentTarget, aOptions);
+                                    } catch(e) {}
+                                }
+                            }
+                            oxTemplateCallbacks = [];
+                        }
                         if ( typeof WidgetsHandler !== 'undefined') {
                             WidgetsHandler.reloadWidget('oxwarticledetails');
                             WidgetsHandler.reloadWidget('oxwrating');


### PR DESCRIPTION
This little hook call custom javascript function `ajaxExecuteTemplateScripts` in templates. We are using two hooks now: `executeTemplateScripts` in base.tpl, and `ajaxExecuteTemplateScripts` in templates like `/widget/product/details.tpl`.

# Why do we need this?

We minify/uglify and concat all Scripts from flow and custom theme into scripts.min.js with Webpack. Also all libraries like jquery, jquery-ui, bootstrap,... are installed via npm/yarn in our theme.

So jquery is no longer available in theme, only in our javascript files. This cause, that [{oxscript}] trigger "$ is not defined" and we have to wrap all [{oxscript add="..."}] scripts into hook like:

```
[{oxscript|regex_replace:"/(.*)<script type=[\"']+text\/javascript[\"']+>[\n]*(.*(?=<\/script>))<\/script>/is":'<script>function executeTemplateScripts(jQuery) {(function($) {$2})(jQuery);}</script>$1'}]
```

What it will create:

```
<script>function executeTemplateScripts(jQuery) {(function($) {oxVariantSelections  = ['0:90e69a94a23be6a2a690e09da9adaa24|','0:9dc9946c94428a693f52af8b0fe026f9|','0:8a0299cef59b2dd74fbd8c5399d1ac0c|','0:81ff08d3e704ec727ec453f90153b51d|','0:367f0e3584fa8732802c8267ccf8a8e1|','0:240628c018bac6738d56b229716564a7|','0:a78d3cead3805f41dd6764fc50f05b26|','0:c9cd1c86d8778f1f985e4cc0190c4c78|','0:45d20b1d2cc2d52e74b3cbf1750a2e31|','0:de52d203c77221f5daac83fe786acddf|','0:0d3d238b089a67e34e39b5abf80db19b|','0:0f338fd7bd3bbdeda49f8a34613570b8|','0:f849bf52fcfd25b0cd6e3f2e74607516|'];
$( document ).ready( function() { console.log('initDetailsEvents');Flow.initDetailsEvents(); });
$( document ).ready( function() { Flow.initEvents();});
var aMorePic=new Array();
$( '#variants' ).oxArticleVariant();
var ol_vpos = ABOVE;
    var ol_cellpad = 0;
    var ol_border = "0";
    var ol_bgcolor = "FFFFFF";
    var ol_width = "205";
    var ol_fgcolor = "FFFFFF";
})(jQuery);}</script><script type="text/javascript" src="https://domain/out/customTheme/src/js/scripts.min.js?1552555978"></script>
<script type="text/javascript" src="https://domain/modules/ifabrik/EnergyLabel/out/src/js/overlib/Mini/overlib_mini.js"></script>
```

*Note:* Its important to inject `executeTemplateScripts` hook right before scripts, so hook can be executet in `scripts.min.js`. But this change is only important for ppl who want to use hook in their theme. This is just an example how we use it, in out custom theme base.tpl.

`main.js` can call this now like:

```
try {
    executeTemplateScripts($);
} catch(e) {}
```

All scripts will be run in defined namespace. Now we also need `ajaxExecuteTemplateScripts` for Ajax-Calls, to prevent double named function and we can separate hooks.

# /widget/product/details.tpl

OXSCRIPT tag `[{oxscript widget=$oView->getClassName()}]` could be now defined like following:

```
[{oxscript|regex_replace:"/(.*)<script type=[\"']+text\/javascript[\"']+>[\n]*(.*(?=<\/script>))<\/script>/is":'<script>function ajaxExecuteTemplateScripts(jQuery) {(function($) {$2})(jQuery);}</script>$1' widget=$oView->getClassName()}]
```

`ajaxExecuteTemplateScripts` will now called in oxArticleVariant-Widget, and with try-catch its totaly optional so no more changes in templates are required.

Maybe this could be first step into automatically assets-loader, what do u think?