### PR TITLE
Add nowrap to email table

### DIFF
--- a/tpl/email/html/order_cust.tpl
+++ b/tpl/email/html/order_cust.tpl
@@ -18,6 +18,7 @@
         border: 1px solid #d4d4d4;
         font-size: 13px;
         padding:5px;
+        white-space: nowrap;
     }
 
     table.orderarticles {

--- a/tpl/email/html/order_owner.tpl
+++ b/tpl/email/html/order_owner.tpl
@@ -16,6 +16,7 @@
         border: 1px solid #d4d4d4;
         font-size: 13px;
         padding:5px;
+        white-space: nowrap;
     }
 
     table.orderarticles {

--- a/tpl/email/html/ordershipped.tpl
+++ b/tpl/email/html/ordershipped.tpl
@@ -10,6 +10,7 @@
         border: 1px solid #d4d4d4;
         font-size: 13px;
         padding:5px;
+        white-space: nowrap;
     }
 
     table.orderarticles {


### PR DESCRIPTION
In upright position on mobile phones, text in coloumns may appear broken with a new line starting at every char, adding nowrap fixes this.
https://forum.oxid-esales.com/t/6-2-e-mail-tabelle-unter-android/96696/8
![0491d6bcaffe8e60ce493392e46a6d7e7e7f026f_2_205x300](https://user-images.githubusercontent.com/2419609/83965503-73e21f00-a8b4-11ea-8806-739cb46c6ae0.png)
