### PR TITLE
added hint to clone before development

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Log into the admin panel, go to *Extensions → Themes → Flow* and press the *
 
 All *Flow* theme related CSS/Javascript files can be found in theme's ``build`` directory. To regenerate the theme's assets, the ``grunt`` tasks should be used. Please install ``grunt`` and run ``grunt's`` default task to regenerate all minimized ``css`` and ``js`` files:
 
+To get the development files you need to [clone the repository](#step-2-get-the-source-code).
+
 1. To use ``grunt``, ``npm`` is required. Check ``nodejs`` website for installation
 instructions (https://nodejs.org/en/download/package-manager/). Example of
 Installation on ubuntu system:


### PR DESCRIPTION
Since the Flow Theme is in the eShop Compilation, most people won't read the *Installation* section, but start with the *Development* section instead. After reading about the `build` directory, you may find out, you don't have one in your (normal) installation. Was removed with Flow 3.1.0 to minimize the Compilation installation to only essential files.

Wave Theme README directly indicates to clone repo:
https://github.com/OXID-eSales/wave-theme#development

I recommend to put this little sentence also to the Flow Theme README.