### PR TITLE
third gender :: add block salutation_options

### DIFF
--- a/tpl/form/fieldset/salutation.tpl
+++ b/tpl/form/fieldset/salutation.tpl
@@ -2,7 +2,9 @@
         [{if $class}]class="[{$class}]"[{/if}]
         [{if $id}]id="[{$id}]"[{/if}]
         [{if $required}]required="required"[{/if}]>
-    <option value="" [{if empty($value)}]SELECTED[{/if}]>[{oxmultilang ident="DD_CONTACT_SELECT_SALUTATION"}]</option>
-    <option value="MRS" [{if $value|lower  == "mrs" or $value2|lower == "mrs"}]SELECTED[{/if}]>[{oxmultilang ident="MRS"}]</option>
-    <option value="MR"  [{if $value|lower  == "mr"  or $value2|lower == "mr"}]SELECTED[{/if}]>[{oxmultilang ident="MR" }]</option>
+    [{block name="salutation_options"}]
+        <option value="" [{if empty($value)}]SELECTED[{/if}]>[{oxmultilang ident="DD_CONTACT_SELECT_SALUTATION"}]</option>
+        <option value="MRS" [{if $value|lower  == "mrs" or $value2|lower == "mrs"}]SELECTED[{/if}]>[{oxmultilang ident="MRS"}]</option>
+        <option value="MR"  [{if $value|lower  == "mr"  or $value2|lower == "mr"}]SELECTED[{/if}]>[{oxmultilang ident="MR" }]</option>
+    [{/block}]
 </select>


### PR DESCRIPTION
Could you please consider adding this block so the salutation options are extendable for third gender.

A judgment of the Regional Court dated December 3rd, 2020 reads something like this:
If a selection of the salutation or gender is made selectable for the user, or is even given as an arrow field, the user must be provided with another option in order not to discriminate against the third gender.

## Additional information / Judgment of the Regional Court
LG Frankfurt am Main - Az. 2-13 O 131/20 - 03.12.2020  
[lto.de](https://www.lto.de/recht/nachrichten/n/lg-frankfurt-am-main-2-13-o-131-20-geschlechtsneutrale-anrede-beim-fahrkartenkauf-diskriminierung-allgemeines-persoenlichkeitsrecht/) |
[onlinehaendler-news.de](https://www.onlinehaendler-news.de/e-recht/aktuelle-urteile/134043-drittes-geschlecht-online-shops-waehlbar)